### PR TITLE
Service: add PATCH  verb/method

### DIFF
--- a/v2/example/example1/example1.go
+++ b/v2/example/example1/example1.go
@@ -1,6 +1,7 @@
 package example1
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/go-restit/restit/v2/example/server"
@@ -28,6 +29,41 @@ func (p *Post) SetID(id string) {
 // GetType implement server.Storable
 func (p Post) GetType() string {
 	return "post"
+}
+
+// PatchWith implements server.Patchable.
+func (p *Post) PatchWith(v interface{}) error {
+	var patch Post
+
+	switch v.(type) {
+	case Post:
+		patch = v.(Post)
+	case *Post:
+		ptr := v.(*Post)
+		patch = *ptr
+	default:
+		return fmt.Errorf("invalid type")
+	}
+
+	if patch.ID != "" {
+		p.ID = patch.ID
+	}
+	if patch.Title != "" {
+		p.Title = patch.Title
+	}
+	if patch.Body != "" {
+		p.Body = patch.Body
+	}
+	if !patch.Created.IsZero() {
+		p.Created = patch.Created
+	}
+	if !patch.Created.IsZero() {
+		p.Updated = patch.Updated
+	} else {
+		p.Updated = time.Now()
+	}
+
+	return nil
 }
 
 // PostServer creates an http.Handler that handles Post

--- a/v2/example/example1/example1_test.go
+++ b/v2/example/example1/example1_test.go
@@ -192,7 +192,7 @@ func TestServer(t *testing.T) {
 		Expect(restit.StatusCodeIs(http.StatusOK)).
 		Expect(restit.LengthIs("posts", 1)).
 		Expect(restit.Nth(0).Of("posts").Is(restit.DescribeJSON(
-			"item #0 returned is equal to p1b", isUpdatedFrom(p1b))))
+			"item #0 retrieved is patched with p1c", isPatchedWith(p1c))))
 	if resp, err := testDelete1.Do(); err != nil {
 		t.Logf("raw response:\n%s\n", resp.Raw())
 		t.Log(err.(restit.ContextError).Log())

--- a/v2/example/server/store.go
+++ b/v2/example/server/store.go
@@ -7,6 +7,11 @@ type Storable interface {
 	SetID(string)
 }
 
+// Patchable is an interface of a structure that can be patched with another partial instance of it.
+type Patchable interface {
+	PatchWith(interface{}) error
+}
+
 // NewStore returns a blank Store
 func NewStore() *Store {
 	return &Store{

--- a/v2/service.go
+++ b/v2/service.go
@@ -98,6 +98,12 @@ func (s Service) Update(payload interface{}, paths ...string) *Case {
 	return s.NewCase("PUT", payload, paths...)
 }
 
+// Patch sends a PATCH request (wtih JSON encoded payload)
+// to singular path and examine the result
+func (s Service) Patch(payload interface{}, paths ...string) *Case {
+	return s.NewCase("PATCH", payload, paths...)
+}
+
 // Retrieve sends a GET request
 // to singular path and examine the result
 func (s Service) Retrieve(paths ...string) *Case {

--- a/v2/service_test.go
+++ b/v2/service_test.go
@@ -113,6 +113,22 @@ func dummyTestSuite(service *restit.Service, baseURL string) (err error) {
 
 	err = func() (err error) {
 		postID := RandString(20)
+		testCase := service.Patch(post{ID: postID, Name: RandString(20)}, postID)
+		if req := testCase.Request; req == nil {
+			err = fmt.Errorf("[update][request] empty")
+		} else if want, have := baseURL+"/"+postID, req.URL.String(); want != have {
+			err = fmt.Errorf("[update][request.URL] expected %#v, got %#v", want, have)
+		} else if want, have := "PATCH", req.Method; want != have {
+			err = fmt.Errorf("[update][request.Method] expected %#v, got %#v", want, have)
+		}
+		return
+	}()
+	if err != nil {
+		return
+	}
+
+	err = func() (err error) {
+		postID := RandString(20)
 		testCase := service.Retrieve(postID)
 		if req := testCase.Request; req == nil {
 			err = fmt.Errorf("[retrieve][request] empty")


### PR DESCRIPTION
Since current `Service.Update` always sends a `PUT` request, to test REST API endpoints that take `PATCH` requests, a support for `PATCH` HTTP verb/method must be implemented.